### PR TITLE
chore: regularly ingest and load public data

### DIFF
--- a/.github/workflows/production-worker-gcs.yml
+++ b/.github/workflows/production-worker-gcs.yml
@@ -1,0 +1,145 @@
+---
+name: "[production] [gcs] all stages / all sites"
+on:
+  workflow_dispatch:
+  schedule:
+      # 6:07, 18:07 in PDT
+      - cron: '7 1,13 * * *'
+
+env:
+  SENTRY_ENABLE: 1
+  SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
+
+jobs:
+  gcs-worker:
+    environment: production
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - name: apt-get dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install libbz2-dev liblzma-dev libreadline-dev libsqlite3-dev pdftohtml
+
+      - uses: actions/checkout@v2
+        with:
+          repository: CAVaccineInventory/vaccine-feed-ingest
+          path: ./vaccine-feed-ingest/
+          submodules: true
+
+      - name: get python version
+        working-directory: vaccine-feed-ingest
+        run: |
+          python_version=$(cat .python-version)
+          echo "python_version=${python_version}" >> $GITHUB_ENV
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.python_version }}
+
+      - name: setup from README.md
+        run: |
+          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+
+      - name: load poetry install from cache
+        id: cached-poetry-dependencies
+        uses: actions/cache@v2
+        with:
+          path: vaccine-feed-ingest/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+
+      - run: poetry install
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        working-directory: vaccine-feed-ingest
+
+      - uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCS_PUBLIC_STORAGE_KEY }}
+          export_default_credentials: true
+
+      - name: run fetch, parse, normalize
+        working-directory: vaccine-feed-ingest
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          poetry run vaccine-feed-ingest pipeline --stages=fetch,parse,normalize --output-dir=gs://vaccine-feeds/locations/ --no-fail-on-runner-error
+
+  gcs-loader:
+    environment: production
+    timeout-minutes: 300
+    runs-on: ubuntu-latest
+    needs:
+      - gcs-worker
+    if: ${{ github.ref == 'refs/heads/main' && success() }}
+    steps:
+      - name: apt-get dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install libbz2-dev liblzma-dev libreadline-dev libsqlite3-dev pdftohtml
+
+      - uses: actions/checkout@v2
+        with:
+          repository: CAVaccineInventory/vaccine-feed-ingest
+          path: ./vaccine-feed-ingest/
+          submodules: true
+
+      - name: get python version
+        working-directory: vaccine-feed-ingest
+        run: |
+          python_version=$(cat .python-version)
+          echo "python_version=${python_version}" >> $GITHUB_ENV
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.python_version }}
+
+      - name: setup from README.md
+        run: |
+          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+
+      - name: load poetry install from cache
+        id: cached-poetry-dependencies
+        uses: actions/cache@v2
+        with:
+          path: vaccine-feed-ingest/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+
+      - run: poetry install
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        working-directory: vaccine-feed-ingest
+
+      - uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCS_PUBLIC_STORAGE_KEY }}
+          export_default_credentials: true
+
+      - name: run enrich, load-to-vial
+        working-directory: vaccine-feed-ingest
+        if: ${{ github.ref == 'refs/heads/main' }}
+        env:
+          OUTPUT_DIR: ${{ secrets.GCS_PUBLIC_OUTPUT_DIR }}
+          VIAL_SERVER: ${{ secrets.VIAL_URI }}
+          VIAL_APIKEY: ${{ secrets.VIAL_API_KEY }}
+          PLACEKEY_APIKEY: ${{ secrets.API_PLACEKEY_KEY }}
+          GEOCODIO_APIKEY: ${{ secrets.API_GEOCODIO_KEY }}
+        run: |
+          poetry run vaccine-feed-ingest pipeline --stages=enrich,load-to-vial --enrich-apis=placekey,geocodio --no-match --no-create --exclude-sites us/giscorps_vaccine_providers
+
+  notify:
+    environment: production
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    needs:
+      - gcs-worker
+      - gcs-loader
+    if: ${{ always() && github.ref == 'refs/heads/main' }}
+    steps:
+      - uses: nobrayner/discord-webhook@v1
+        with:
+          username: "[production] data pipeline"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # vaccine-feed-ingest-public-worker
 
 <!-- markdownlint-disable MD013 -->
-| environment | repo ingest | private load |
-|-|-|-|
-| prod | [![production - repo - all stages / all sites](https://github.com/CAVaccineInventory/vaccine-feed-ingest-public-worker/actions/workflows/production-worker-repo.yml/badge.svg?branch=main)](https://github.com/CAVaccineInventory/vaccine-feed-ingest-public-worker/actions/workflows/production-worker-repo.yml) | [![production - private - load-to-vial](https://github.com/CAVaccineInventory/vaccine-feed-ingest-public-worker/actions/workflows/production-loader-private-gcs.yml/badge.svg?branch=main)](https://github.com/CAVaccineInventory/vaccine-feed-ingest-public-worker/actions/workflows/production-loader-private-gcs.yml) |
+| environment | repo ingest | public ingest + load | private load |
+|-|-|-|-|
+| prod | [![production - repo - all stages / all sites](https://github.com/CAVaccineInventory/vaccine-feed-ingest-public-worker/actions/workflows/production-worker-repo.yml/badge.svg?branch=main)](https://github.com/CAVaccineInventory/vaccine-feed-ingest-public-worker/actions/workflows/production-worker-repo.yml) | [![production - public - worker](https://github.com/CAVaccineInventory/vaccine-feed-ingest-public-worker/actions/workflows/production-worker-gcs.yml/badge.svg?branch=main)](https://github.com/CAVaccineInventory/vaccine-feed-ingest-public-worker/actions/workflows/production-worker-gcs.yml) | [![production - private - load-to-vial](https://github.com/CAVaccineInventory/vaccine-feed-ingest-public-worker/actions/workflows/production-loader-private-gcs.yml/badge.svg?branch=main)](https://github.com/CAVaccineInventory/vaccine-feed-ingest-public-worker/actions/workflows/production-loader-private-gcs.yml) |
 <!-- markdownlint-restore -->
 
 [`vaccine-feed-ingest`](https://github.com/CAVaccineInventory/vaccine-feed-ingest) is an open-source repo which accepts contributions of ingestors from the public.


### PR DESCRIPTION
Some sites are presently excluded from the enrich + load-to-vial stages. These sites have historically required heavy enrichment, which can be costly (due to many records needing enrichment using remote services). They should be re-validated, and ideally re-enabled, whenever time allows.